### PR TITLE
Update some dependencies

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Run checks
     env:
-      PYTHON_VERSION: 3.11.9
+      PYTHON_VERSION: 3.11.10
     defaults:
       run:
         shell: bash -leo pipefail {0}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /bot
 
 RUN apt-get -y update \
     && apt-get -y upgrade \
-    && apt-get --no-install-recommends -y install git=1:2.39.2-1.1 \
+    && apt-get --no-install-recommends -y install git=1:2.39.* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Use the command `hadolint Dockerfile` to test
 # Adding Hadolint to `pre-commit` is non-trivial, so the command must be run manually
 
-FROM python:3.11.9-slim-bookworm AS achilles
+FROM python:3.11.10-slim-bookworm AS achilles
 
 WORKDIR /bot
 


### PR DESCRIPTION
This PR just updates some dependencies. The Git update is needed for the OCI image to build, and the Python update just switches to the latest patch version.