### PR TITLE
Limit bot actions by bot type

### DIFF
--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -133,6 +133,12 @@ class BaselineBot(ABC):
         Args:
             orders: Orders to suggest.
         """
+        if self.bot_type != BotType.ADVISOR:
+            raise TypeError(
+                f"{self.suggest_orders.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"because it is not a {BotType.ADVISOR}"
+            )
+
         await self.send_message(
             diplomacy_strings.GLOBAL,
             f"{self.power_name}: {', '.join(orders)}",
@@ -147,6 +153,12 @@ class BaselineBot(ABC):
             recipient: The name of the power that would receive the recommended message.
             message: Text of the recommended message.
         """
+        if self.bot_type != BotType.ADVISOR:
+            raise TypeError(
+                f"{self.suggest_message.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"because it is not a {BotType.ADVISOR}"
+            )
+
         await self.send_message(
             diplomacy_strings.GLOBAL,
             f"{self.power_name}-{recipient}: {message}",
@@ -174,6 +186,12 @@ class BaselineBot(ABC):
             orders: Orders to send.
             wait: Whether the server should be told to wait for further orders.
         """
+        if self.bot_type != BotType.PLAYER:
+            raise TypeError(
+                f"{self.send_orders.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"because it is not a {BotType.PLAYER}"
+            )
+
         logger.info("Sent orders: %s", orders)
 
         # Orders should not be sent in local games, only stored

--- a/src/chiron_utils/scripts/run_bot.py
+++ b/src/chiron_utils/scripts/run_bot.py
@@ -79,8 +79,9 @@ async def play(
             # Fetch orders from bot
             orders_data = await bot()
 
-            # Always send orders so engine knows turn is over
-            await bot.send_orders(orders_data)
+            if bot.bot_type == BotType.PLAYER:
+                # Always send orders so engine knows turn is over
+                await bot.send_orders(orders_data)
 
         phase_end_time = time.time()
         logger.info(


### PR DESCRIPTION
We were sending orders as an advisor, which might have been causing the phase synchronization problems we've been seeing. In addition to explicitly fixing this bug, I added some checks to raise an error if a method is not supposed to be called by a specific bot type.