### PR TITLE
Update `diplomacy`

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.3.2
 coloredlogs==15.0.1
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
 dill==0.3.8
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@1f6ce8803bfd35a3ebbcf9ded7325434f72d966a
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@232740abe53e18476c0f5d6de806e07f5d12b434
 distlib==0.3.8
 filelock==3.15.4
 humanfriendly==10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@1f6ce8803bfd35a3ebbcf9ded7325434f72d966a
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@232740abe53e18476c0f5d6de806e07f5d12b434
 tornado


### PR DESCRIPTION
Most of the changes were to building the engine's OCI image, but one commit, <https://github.com/ALLAN-DIP/diplomacy/commit/232740abe53e18476c0f5d6de806e07f5d12b434>, is needed to run the CICERO advisor.