### PR TITLE
Prepare for integration into CICERO advisor

### DIFF
--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -135,11 +135,14 @@ class BaselineBot(ABC):
             msg_type=diplomacy_strings.HAS_SUGGESTIONS,
         )
 
-    async def suggest_orders(self, orders: List[str]) -> None:
+    async def suggest_orders(
+        self, orders: List[str], *, partial_orders: Optional[List[str]] = None
+    ) -> None:
         """Send suggested orders for power to the server.
 
         Args:
             orders: Orders to suggest.
+            partial_orders: Orders already set by the player.
         """
         if self.bot_type != BotType.ADVISOR:
             raise TypeError(
@@ -147,11 +150,18 @@ class BaselineBot(ABC):
                 f"because it is not a {BotType.ADVISOR}"
             )
 
+        if partial_orders:
+            message = f"{self.power_name}:{', '.join(partial_orders)} : {', '.join(orders)}"
+            suggestion_type = diplomacy_strings.SUGGESTED_MOVE_PARTIAL
+        else:
+            message = f"{self.power_name}: {', '.join(orders)}"
+            suggestion_type = diplomacy_strings.SUGGESTED_MOVE_FULL
+
         await self.send_message(
             diplomacy_strings.GLOBAL,
-            f"{self.power_name}: {', '.join(orders)}",
+            message,
             sender=diplomacy_strings.OMNISCIENT_TYPE,
-            msg_type=diplomacy_strings.SUGGESTED_MOVE_FULL,
+            msg_type=suggestion_type,
         )
 
     async def suggest_message(self, recipient: str, message: str) -> None:

--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -114,6 +114,7 @@ class RandomProposerBot(BaselineBot, ABC):
         return orders
 
 
+@dataclass
 class RandomProposerAdvisor(RandomProposerBot):
     """Advisor form of `RandomProposerBot`."""
 
@@ -121,6 +122,7 @@ class RandomProposerAdvisor(RandomProposerBot):
     suggestion_type = SuggestionType.MESSAGE_AND_MOVE
 
 
+@dataclass
 class RandomProposerPlayer(RandomProposerBot):
     """Player form of `RandomProposerBot`."""
 


### PR DESCRIPTION
This PR contains changes needed for using `chiron-utils` in the CICERO advisor. I made and tested these commits during my integration work.