### PR TITLE
Make `run_cicero.sh` more consistent with `run_bot.py`

### DIFF
--- a/scripts/run_cicero.sh
+++ b/scripts/run_cicero.sh
@@ -2,29 +2,29 @@
 
 set -euxo pipefail
 
-GAME_ID=$1
-HOST=$2
-POWER=$3
-shift 3
+BOT_NAME=$1
+shift 1
 
 CICERO_DIR=/media/volume/cicero-base-models
 
 GAME_COMMAND=(
   python fairdiplomacy_external/mila_api.py
-  --game_id "$GAME_ID"
-  --host "$HOST"
-  --use-ssl
-  --power "$POWER"
   --game_type 2
+  "$@"
 )
+
+mkdir -p logs/
+NOW=$(date -u +'%Y_%m_%d_%H_%M_%S')
+LOG_FILE=logs/$NOW.txt
 
 time docker run \
   --rm \
   --gpus all \
-  --name cicero_"$GAME_ID"_"$POWER" \
+  --name cicero_"$BOT_NAME"_"$RANDOM" \
   --volume "$CICERO_DIR"/agents:/diplomacy_cicero/conf/common/agents:ro \
   --volume "$CICERO_DIR"/gpt2:/usr/local/lib/python3.7/site-packages/data/gpt2:ro \
   --volume "$CICERO_DIR"/models:/diplomacy_cicero/models:ro \
   --workdir /diplomacy_cicero \
-  ghcr.io/allan-dip/diplomacy_cicero:human_experiments-alex \
-  "${GAME_COMMAND[@]}" "$@"
+  ghcr.io/allan-dip/diplomacy_cicero:"$BOT_NAME" \
+  "${GAME_COMMAND[@]}" |&
+  tee "$LOG_FILE"


### PR DESCRIPTION
It is now easier to run `run_cicero.sh` because more arguments are being passed directly to CICERO. In addition, the script now automatically logs container output to a file to make it easier to share for debugging.