### PR TITLE
Support commentary advice

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.3.2
 coloredlogs==15.0.1
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
 dill==0.3.8
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@33414ee202cd6c83ba33b8867669ad03611dc05c
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@3cf9282044bf4ccb532fcece7419547e09b50fa5
 distlib==0.3.8
 filelock==3.15.4
 humanfriendly==10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@33414ee202cd6c83ba33b8867669ad03611dc05c
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@3cf9282044bf4ccb532fcece7419547e09b50fa5
 tornado

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -179,7 +179,27 @@ class BaselineBot(ABC):
 
         await self.send_message(
             diplomacy_strings.GLOBAL,
-            f"{self.power_name}-{recipient}: {message}",
+            f"{self.power_name}-{recipient}:message:{message}",
+            sender=diplomacy_strings.OMNISCIENT_TYPE,
+            msg_type=diplomacy_strings.SUGGESTED_MESSAGE,
+        )
+
+    async def suggest_commentary(self, recipient: str, message: str) -> None:
+        """Send suggested commentary for power to the server.
+
+        Args:
+            recipient: The name of the power that the commentary is about.
+            message: Text of the commentary.
+        """
+        if self.bot_type != BotType.ADVISOR:
+            raise TypeError(
+                f"{self.suggest_message.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"because it is not a {BotType.ADVISOR}"
+            )
+
+        await self.send_message(
+            diplomacy_strings.GLOBAL,
+            f"{self.power_name}-{recipient}:commentary:{message}",
             sender=diplomacy_strings.OMNISCIENT_TYPE,
             msg_type=diplomacy_strings.SUGGESTED_MESSAGE,
         )

--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -79,6 +79,7 @@ class RandomProposerBot(BaselineBot, ABC):
         for other_power, suggested_random_orders in random_order_proposals.items():
             if self.bot_type == BotType.ADVISOR:
                 await self.suggest_message(other_power, suggested_random_orders)
+                await self.suggest_commentary(other_power, f"I have advice about {other_power}!")
             elif self.bot_type == BotType.PLAYER:
                 await self.send_message(other_power, suggested_random_orders)
 
@@ -119,7 +120,7 @@ class RandomProposerAdvisor(RandomProposerBot):
     """Advisor form of `RandomProposerBot`."""
 
     bot_type = BotType.ADVISOR
-    suggestion_type = SuggestionType.MESSAGE_AND_MOVE
+    suggestion_type = SuggestionType.MESSAGE | SuggestionType.MOVE | SuggestionType.COMMENTARY
 
 
 @dataclass


### PR DESCRIPTION
This PR adds support for a new type of advice: commentary. It pulls in relevant changes from the engine, adds a new method to send commentary advice, and generates it in `RandomProposerAdvisor` for easily testing the UI.