### PR TITLE
Add support for predicting opponent orders

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.3.2
 coloredlogs==15.0.1
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
 dill==0.3.9
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@2d1368d8e35f98618fd4750a5afc8f79662eadb7
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@3af242e3db6dffc1e6683389274f6f1d1ae2a728
 distlib==0.3.9
 filelock==3.16.1
 humanfriendly==10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 daidepp @ git+https://git@github.com/SHADE-AI/daidepp.git@7f6dcca60f2e6dd89c37862663be7b098cc03794
 # Pinned `diplomacy` to `main`
-diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@2d1368d8e35f98618fd4750a5afc8f79662eadb7
+diplomacy @ git+https://git@github.com/ALLAN-DIP/diplomacy.git@3af242e3db6dffc1e6683389274f6f1d1ae2a728
 tornado

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -138,7 +138,7 @@ class BaselineBot(ABC):
         )
 
     async def suggest_orders(
-        self, orders: List[str], *, partial_orders: Optional[List[str]] = None
+        self, orders: Sequence[str], *, partial_orders: Optional[Sequence[str]] = None
     ) -> None:
         """Send suggested orders for power to the server.
 

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 import os
 import random
-from typing import ClassVar, List, Optional, Sequence
+from typing import Any, ClassVar, List, Mapping, Optional, Sequence
 
 from diplomacy import Game, Message
 from diplomacy.client.network_game import NetworkGame
@@ -117,6 +117,20 @@ class BaselineBot(ABC):
         else:
             self.game.add_message(message=msg_obj)
 
+    async def send_suggestion(self, message_dict: Mapping[str, Any], suggestion_type: str) -> None:
+        """Send suggestion message to the server.
+
+        Args:
+            message_dict: Dictionary mapping powers to suggestions intended for them.
+            suggestion_type: Type of suggestion (e.g., `"has_suggestions"`, `"suggested_message"`).
+        """
+        await self.send_message(
+            diplomacy_strings.GLOBAL,
+            message=serialize_message_dict(message_dict),
+            sender=diplomacy_strings.OMNISCIENT_TYPE,
+            msg_type=suggestion_type,
+        )
+
     async def declare_suggestion_type(self) -> None:
         """Declare the advisor's suggestion type to the engine."""
         if self.bot_type != BotType.ADVISOR:
@@ -130,11 +144,9 @@ class BaselineBot(ABC):
         # Explicit `int` cast is needed before Python 3.11
         message_dict = {self.power_name: int(self.suggestion_type)}
 
-        await self.send_message(
-            diplomacy_strings.GLOBAL,
-            message=serialize_message_dict(message_dict),
-            sender=diplomacy_strings.OMNISCIENT_TYPE,
-            msg_type=diplomacy_strings.HAS_SUGGESTIONS,
+        await self.send_suggestion(
+            message_dict=message_dict,
+            suggestion_type=diplomacy_strings.HAS_SUGGESTIONS,
         )
 
     async def suggest_orders(
@@ -161,11 +173,9 @@ class BaselineBot(ABC):
             message_dict = {self.power_name: {"suggested_orders": orders}}
             suggestion_type = diplomacy_strings.SUGGESTED_MOVE_FULL
 
-        await self.send_message(
-            diplomacy_strings.GLOBAL,
-            message=serialize_message_dict(message_dict),
-            sender=diplomacy_strings.OMNISCIENT_TYPE,
-            msg_type=suggestion_type,
+        await self.send_suggestion(
+            message_dict=message_dict,
+            suggestion_type=suggestion_type,
         )
 
     async def suggest_message(self, recipient: str, message: str) -> None:
@@ -183,11 +193,9 @@ class BaselineBot(ABC):
 
         message_dict = {self.power_name: {"recipient": recipient, "message": message}}
 
-        await self.send_message(
-            diplomacy_strings.GLOBAL,
-            message=serialize_message_dict(message_dict),
-            sender=diplomacy_strings.OMNISCIENT_TYPE,
-            msg_type=diplomacy_strings.SUGGESTED_MESSAGE,
+        await self.send_suggestion(
+            message_dict=message_dict,
+            suggestion_type=diplomacy_strings.SUGGESTED_MESSAGE,
         )
 
     async def suggest_commentary(self, recipient: str, message: str) -> None:
@@ -205,11 +213,9 @@ class BaselineBot(ABC):
 
         message_dict = {self.power_name: {"recipient": recipient, "commentary": message}}
 
-        await self.send_message(
-            diplomacy_strings.GLOBAL,
-            message=serialize_message_dict(message_dict),
-            sender=diplomacy_strings.OMNISCIENT_TYPE,
-            msg_type=diplomacy_strings.SUGGESTED_COMMENTARY,
+        await self.send_suggestion(
+            message_dict=message_dict,
+            suggestion_type=diplomacy_strings.SUGGESTED_COMMENTARY,
         )
 
     async def send_intent_log(self, log_msg: str) -> None:

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 import os
 import random
-from typing import Any, ClassVar, List, Optional, Sequence
+from typing import Any, ClassVar, List, Mapping, Optional, Sequence
 
 from diplomacy import Game, Message
 from diplomacy.client.network_game import NetworkGame
@@ -180,6 +180,25 @@ class BaselineBot(ABC):
         await self.send_suggestion(
             payload=payload,
             suggestion_type=suggestion_type,
+        )
+
+    async def suggest_opponent_orders(self, opponent_orders: Mapping[str, Sequence[str]]) -> None:
+        """Send predicted orders for opponent powers to the server.
+
+        Args:
+            opponent_orders: Mapping from opponent powers to their predicted orders.
+        """
+        if self.bot_type != BotType.ADVISOR:
+            raise TypeError(
+                f"{self.suggest_opponent_orders.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"because it is not a {BotType.ADVISOR}"
+            )
+
+        payload = {"predicted_orders": opponent_orders}
+
+        await self.send_suggestion(
+            payload=payload,
+            suggestion_type=diplomacy_strings.SUGGESTED_MOVE_OPPONENTS,
         )
 
     async def suggest_message(self, recipient: str, message: str) -> None:

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -125,6 +125,7 @@ class BaselineBot(ABC):
             suggestion_type: Type of suggestion (e.g., `"has_suggestions"`, `"suggested_message"`).
         """
         message_dict = {
+            "advisor": self.display_name,
             "recipient": self.power_name,
             "payload": payload,
         }

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -199,7 +199,7 @@ class BaselineBot(ABC):
         """
         if self.bot_type != BotType.ADVISOR:
             raise TypeError(
-                f"{self.suggest_message.__name__!r} cannot be called by {self.__class__.__name__!r} "
+                f"{self.suggest_commentary.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
             )
 

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -144,8 +144,11 @@ class BaselineBot(ABC):
                 f"{self.declare_suggestion_type.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
             )
-
-        assert self.suggestion_type is not None
+        if self.suggestion_type is None:
+            raise ValueError(
+                f"{self.declare_suggestion_type.__name__!r} cannot be called because "
+                f"it does not support any suggestion types"
+            )
 
         # Explicit `int` cast is needed before Python 3.11
         payload = int(self.suggestion_type)
@@ -168,6 +171,11 @@ class BaselineBot(ABC):
             raise TypeError(
                 f"{self.suggest_orders.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
+            )
+        if not self.suggestion_type & SuggestionType.MOVE:
+            raise ValueError(
+                f"{self.suggest_orders.__name__!r} cannot be called because "
+                f"it does not provide {SuggestionType.MOVE.name} suggestions"
             )
 
         payload = {"suggested_orders": orders}
@@ -193,6 +201,11 @@ class BaselineBot(ABC):
                 f"{self.suggest_opponent_orders.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
             )
+        if not self.suggestion_type & SuggestionType.OPPONENT_MOVE:
+            raise ValueError(
+                f"{self.suggest_opponent_orders.__name__!r} cannot be called because "
+                f"it does not provide {SuggestionType.OPPONENT_MOVE.name} suggestions"
+            )
 
         payload = {"predicted_orders": opponent_orders}
 
@@ -213,6 +226,11 @@ class BaselineBot(ABC):
                 f"{self.suggest_message.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
             )
+        if not self.suggestion_type & SuggestionType.MESSAGE:
+            raise ValueError(
+                f"{self.suggest_message.__name__!r} cannot be called because "
+                f"it does not provide {SuggestionType.MESSAGE.name} suggestions"
+            )
 
         payload = {"recipient": recipient, "message": message}
 
@@ -232,6 +250,11 @@ class BaselineBot(ABC):
             raise TypeError(
                 f"{self.suggest_commentary.__name__!r} cannot be called by {self.__class__.__name__!r} "
                 f"because it is not a {BotType.ADVISOR}"
+            )
+        if not self.suggestion_type & SuggestionType.COMMENTARY:
+            raise ValueError(
+                f"{self.suggest_commentary.__name__!r} cannot be called because "
+                f"it does not provide {SuggestionType.COMMENTARY.name} suggestions"
             )
 
         payload = {"recipient": recipient, "commentary": message}

--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -3,7 +3,7 @@
 from abc import ABC
 from dataclasses import dataclass
 import random
-from typing import Dict, List, Sequence
+from typing import Dict, List, Optional, Sequence
 
 from daidepp import AND, PRP, XDO
 from diplomacy.utils import strings as diplomacy_strings
@@ -88,16 +88,23 @@ class RandomProposerBot(BaselineBot, ABC):
 
         return list(orders)
 
-    def get_random_orders(self) -> List[str]:
-        """Generate random orders to carry out.
+    def get_random_orders(self, power_name: Optional[str] = None) -> List[str]:
+        """Generate random orders for a power to carry out.
+
+        Args:
+            power_name: Name of power to generate random orders for.
+                Defaults to current power.
 
         Returns:
             List of random orders.
         """
+        if power_name is None:
+            power_name = self.power_name
+
         possible_orders = self.game.get_all_possible_orders()
         orders = [
             random.choice(list(possible_orders[loc]))
-            for loc in self.game.get_orderable_locations(self.power_name)
+            for loc in self.game.get_orderable_locations(power_name)
             if possible_orders[loc]
         ]
         return orders

--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -35,18 +35,11 @@ class RandomProposerBot(BaselineBot, ABC):
         Returns:
             Mapping from powers to random order proposals.
         """
-        # Getting the list of possible orders for all locations
-        possible_orders = self.game.get_all_possible_orders()
-
         proposals = {}
 
         # For each power, randomly sample a valid order
         for other_power in get_other_powers([self.power_name], self.game):
-            suggested_random_orders = [
-                random.choice(possible_orders[loc])
-                for loc in self.game.get_orderable_locations(other_power)
-                if possible_orders[loc]
-            ]
+            suggested_random_orders = self.get_random_orders(other_power)
             suggested_random_orders = list(
                 filter(
                     lambda x: x != diplomacy_strings.WAIVE

--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -111,6 +111,11 @@ class RandomProposerBot(BaselineBot, ABC):
         orders = self.get_random_orders()
         if self.bot_type == BotType.ADVISOR:
             await self.suggest_orders(orders)
+
+            random_predicted_orders = {}
+            for other_power in get_other_powers([self.power_name], self.game):
+                random_predicted_orders[other_power] = self.get_random_orders(other_power)
+            await self.suggest_opponent_orders(random_predicted_orders)
         elif self.bot_type == BotType.PLAYER:
             await self.send_orders(orders, wait=True)
         return orders
@@ -121,7 +126,12 @@ class RandomProposerAdvisor(RandomProposerBot):
     """Advisor form of `RandomProposerBot`."""
 
     bot_type = BotType.ADVISOR
-    suggestion_type = SuggestionType.MESSAGE | SuggestionType.MOVE | SuggestionType.COMMENTARY
+    suggestion_type = (
+        SuggestionType.MESSAGE
+        | SuggestionType.MOVE
+        | SuggestionType.COMMENTARY
+        | SuggestionType.OPPONENT_MOVE
+    )
 
 
 @dataclass


### PR DESCRIPTION
This PR adds client support for a new suggestion type that predicts the orders of opponents. This change required *another* refactor of the suggestion format, but the previous refactors made it *significantly* easier this time! I also made some related improvements to the suggestion code and added a test implementation to `RandomProposerAdvisor`.

For the library and UI implementations, see <https://github.com/ALLAN-DIP/diplomacy/pull/34>. For the CICERO implementation, see <https://github.com/ALLAN-DIP/diplomacy_cicero/pull/32>.