### PR TITLE
Improve typing for `suggest_orders_probabilities()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
   'importlib-metadata>=3.7.0 ; python_version < "3.10"',
   # `tornado` `3.1` introduced `ASYNC_TEST_TIMEOUT` environment variable
   "tornado>=3.1",
+  # `typing_extensions` `3.10.0.0` introduced `TypedDict` and other types added in Python 3.8
+  'typing_extensions>=3.10.0.0 ; python_version < "3.8"',
 ]
 
 [project.optional-dependencies]

--- a/src/chiron_utils/bots/baseline_bot.py
+++ b/src/chiron_utils/bots/baseline_bot.py
@@ -8,6 +8,11 @@ import os
 import random
 from typing import Any, ClassVar, List, Mapping, Optional, Sequence
 
+try:
+    from typing import TypedDict  # type: ignore[attr-defined]
+except ImportError:
+    from typing_extensions import TypedDict
+
 from diplomacy import Game, Message
 from diplomacy.client.network_game import NetworkGame
 from diplomacy.utils import strings as diplomacy_strings
@@ -23,6 +28,20 @@ class BotType(str, Enum):
 
     ADVISOR = auto()
     PLAYER = auto()
+
+
+class OrderProbability(TypedDict):  # type: ignore[misc]
+    """Probability information for a single order.
+
+    Attributes:
+        pred_prob: Predicted probability of order.
+        rank: Determined by predicted probability sorted in decreasing order.
+        opacity: Normalized probability, used for rendering opacity.
+    """
+
+    pred_prob: float
+    rank: int
+    opacity: float
 
 
 DEFAULT_COMM_STAGE_LENGTH = 300  # 5 minutes in seconds
@@ -222,7 +241,7 @@ class BaselineBot(ABC):
         )
 
     async def suggest_orders_probabilities(
-        self, province: str, orders_probabilities: Mapping[str, Mapping[str, Any]]
+        self, province: str, orders_probabilities: Mapping[str, OrderProbability]
     ) -> None:
         """Send probabilities for suggested orders to the server.
 


### PR DESCRIPTION
The method's interface was undocumented and relied on passing in the output of `baseline-models` directly. Now that I am adding support for order probability advice to Cicero, the interface needs to actually be documented so I can construct data in the proper format.

The change was mostly straightforward, but the best way to properly document a `dict`'s structure is the use of `TypedDict`, which was introduced in Python 3.8. Because Cicero is stuck on Python 3.7, I needed to add `typing_extensions` as a direct dependency. This doesn't really change anything because it was an indirect requirement, anyway.