### PR TITLE
Prevent sending and suggestion of invalid orders

### DIFF
--- a/src/chiron_utils/bots/random_proposer_bot.py
+++ b/src/chiron_utils/bots/random_proposer_bot.py
@@ -11,7 +11,7 @@ from diplomacy.utils.constants import SuggestionType
 
 from chiron_utils.bots.baseline_bot import BaselineBot, BotType
 from chiron_utils.daide2eng import gen_english
-from chiron_utils.parsing_utils import dipnet_to_daide_parsing
+from chiron_utils.parsing_utils import parse_dipnet_to_daide
 from chiron_utils.utils import get_other_powers
 
 
@@ -48,7 +48,7 @@ class RandomProposerBot(BaselineBot, ABC):
                 )
             )
             if len(suggested_random_orders) > 0:
-                commands = dipnet_to_daide_parsing(suggested_random_orders, self.game)
+                commands = parse_dipnet_to_daide(suggested_random_orders, self.game)
                 random_orders = [XDO(command) for command in commands]
                 if len(random_orders) > 1:
                     suggested_random_orders = PRP(AND(*random_orders))

--- a/src/chiron_utils/parsing_utils.py
+++ b/src/chiron_utils/parsing_utils.py
@@ -91,7 +91,7 @@ def daidefy_unit(dipnet_unit: str, unit_game_mapping: Mapping[str, str]) -> Unit
     return unit
 
 
-def dipnet_to_daide_parsing(
+def parse_dipnet_to_daide(
     dipnet_style_order_strs: Sequence[Union[str, Tuple[str, str]]],
     game: Game,
     *,
@@ -228,7 +228,7 @@ def dipnet_to_daide_parsing(
             logger.exception(
                 "ALLAN: error from %s.%s()\n\tOrder with error: %r\n\tSet of orders: %s",
                 __name__,
-                dipnet_to_daide_parsing.__name__,
+                parse_dipnet_to_daide.__name__,
                 " ".join(dipnet_order_tokens),
                 dipnet_style_order_strs,
             )
@@ -273,7 +273,7 @@ def dipnetify_unit(unit: Unit) -> str:
     return f"{unit_type} {location}"
 
 
-def daide_to_dipnet_parsing(daide_order: Command) -> Optional[Tuple[str, str]]:
+def parse_daide_to_dipnet(daide_order: Command) -> Optional[Tuple[str, str]]:
     """Convert single DAIDE-style order to DipNet-style order.
 
     Args:
@@ -321,7 +321,7 @@ def daide_to_dipnet_parsing(daide_order: Command) -> Optional[Tuple[str, str]]:
         logger.exception(
             "ALLAN: error from %s.%s\n\tCould not convert DAIDE command %r to DipNet format",
             __name__,
-            daide_to_dipnet_parsing.__name__,
+            parse_daide_to_dipnet.__name__,
             str(daide_order),
         )
         if DEBUG_MODE:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Union
 from diplomacy import Game
 import pytest
 
-from chiron_utils.parsing_utils import daide_to_dipnet_parsing, dipnet_to_daide_parsing
+from chiron_utils.parsing_utils import parse_daide_to_dipnet, parse_dipnet_to_daide
 from chiron_utils.utils import get_order_tokens, parse_daide
 
 
@@ -67,7 +67,7 @@ class TestUtils:
 
         assert [
             str(c)
-            for c in dipnet_to_daide_parsing(
+            for c in parse_dipnet_to_daide(
                 test_input,
                 game_tc,
                 unit_power_tuples_included=unit_power_tuples_included,
@@ -75,7 +75,7 @@ class TestUtils:
         ] == expected, (
             [
                 str(c)
-                for c in dipnet_to_daide_parsing(
+                for c in parse_dipnet_to_daide(
                     test_input,
                     game_tc,
                     unit_power_tuples_included=unit_power_tuples_included,
@@ -96,7 +96,7 @@ class TestUtils:
             "/WC",
         }:
             comparison_tc_op = comparison_tc_op.rsplit("/", maxsplit=1)[0]
-        dipnet_order = daide_to_dipnet_parsing(parse_daide(expected[0]))
+        dipnet_order = parse_daide_to_dipnet(parse_daide(expected[0]))
         assert dipnet_order is not None
         assert dipnet_order[0] == comparison_tc_op, (dipnet_order, comparison_tc_op)
 
@@ -132,12 +132,12 @@ class TestUtils:
         game_tc = Game()
         game_tc.set_units("ITALY", ["A TUN", "F ION", "F EAS", "F AEG"])
 
-        assert [str(c) for c in dipnet_to_daide_parsing(test_input, game_tc)] == expected, (
-            [str(c) for c in dipnet_to_daide_parsing(test_input, game_tc)],
+        assert [str(c) for c in parse_dipnet_to_daide(test_input, game_tc)] == expected, (
+            [str(c) for c in parse_dipnet_to_daide(test_input, game_tc)],
             expected,
         )
         for tc_ip_ord, tc_op_ord in zip(test_input, expected):
-            dipnet_order = daide_to_dipnet_parsing(parse_daide(tc_op_ord))
+            dipnet_order = parse_daide_to_dipnet(parse_daide(tc_op_ord))
             assert dipnet_order is not None
             assert dipnet_order[0] == tc_ip_ord.replace(" R ", " - "), (
                 dipnet_order,


### PR DESCRIPTION
For <https://github.com/ALLAN-DIP/diplomacy/issues/87>.

This PR will hopefully prevent any more invalid orders from crashing the UI, but it will require updating the various bots that use it (e.g., Cicero) to take full effect.