### PR TITLE
Improve message reading API to prevent leakage

### DIFF
--- a/src/chiron_utils/bots/csu_faaf_advisor_bot.py
+++ b/src/chiron_utils/bots/csu_faaf_advisor_bot.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from dataclasses import dataclass, field
-import json
 import random
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -85,7 +84,7 @@ class FaafAdvisor(BaselineBot):
         return "\n".join(lines)
 
     def format_prompt_phase1(
-        self, own: str, suggest_orders: List[str], own_orders: List[str]
+        self, own: str, suggest_orders: Dict[str, List[str]], own_orders: List[str]
     ) -> Optional[str]:
         """Create prompt used as input to the LLM.
 
@@ -102,11 +101,8 @@ class FaafAdvisor(BaselineBot):
         sorted_board_states = {key: sorted(value) for key, value in board_states.items()}
         formated_board_states = self.format_boardstates(sorted_board_states)
         # opponent order prediction
-        parsed_data = json.loads(suggest_orders[0])
-        predicted_orders = parsed_data["payload"]["predicted_orders"]
-        formatted_opponent_orders = predicted_orders
         formatted_opponent_orders = "\n".join(
-            f"{power}: " + ", ".join(predicted_orders[power]) for power in predicted_orders
+            f"{power}: " + ", ".join(suggest_orders[power]) for power in suggest_orders
         )
         # own recommended order format
         formatted_recommended_orders = ", ".join(own_orders)
@@ -148,7 +144,11 @@ class FaafAdvisor(BaselineBot):
         return prompt
 
     def format_prompt_phase2(
-        self, own: str, suggest_orders: List[str], own_orders: List[str], rationales: Optional[str]
+        self,
+        own: str,
+        suggest_orders: Dict[str, List[str]],
+        own_orders: List[str],
+        rationales: Optional[str],
     ) -> Optional[str]:
         """Create prompt used as input to the LLM.
 
@@ -162,12 +162,8 @@ class FaafAdvisor(BaselineBot):
         sorted_board_states = {key: sorted(value) for key, value in board_states.items()}
         formated_board_states = self.format_boardstates(sorted_board_states)
 
-        parsed_data = json.loads(suggest_orders[0])
-        predicted_orders = parsed_data["payload"]["predicted_orders"]
-        formatted_opponent_orders = predicted_orders
-
         formatted_opponent_orders = "\n".join(
-            f"{power}: " + ", ".join(predicted_orders[power]) for power in predicted_orders
+            f"{power}: " + ", ".join(suggest_orders[power]) for power in suggest_orders
         )
         formatted_recommended_orders = ", ".join(own_orders)
         if formatted_recommended_orders == "":

--- a/src/chiron_utils/bots/llm_advisor_bot.py
+++ b/src/chiron_utils/bots/llm_advisor_bot.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from dataclasses import dataclass, field
-import json
 import random
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -175,7 +174,9 @@ Now let's see the question:"""
 
         return " ".join(mapped_words)
 
-    def format_prompt_phase1(self, own: str, oppo: str, suggest_orders: List[str]) -> Optional[str]:
+    def format_prompt_phase1(
+        self, own: str, oppo: str, suggest_orders: Dict[str, List[str]]
+    ) -> Optional[str]:
         """Create prompt used as input to the LLM.
 
         Returns:
@@ -204,8 +205,7 @@ Now let's see the question:"""
         message_history = ""
         for msg in recent_msgs:
             message_history += f"Message from {msg.sender}:'{msg.message}' "
-        parsed_data = json.loads(suggest_orders[0])
-        predicted_orders = parsed_data["payload"]["predicted_orders"][oppo]
+        predicted_orders = suggest_orders[oppo]
 
         orders_string = ", ".join(predicted_orders)
 

--- a/src/chiron_utils/bots/llm_advisor_new_bot.py
+++ b/src/chiron_utils/bots/llm_advisor_new_bot.py
@@ -2,7 +2,6 @@
 
 import asyncio
 from dataclasses import dataclass, field
-import json
 import random
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -126,7 +125,7 @@ A MUN - BUR:
         return "\n".join(lines)
 
     def format_prompt_phase1(
-        self, own: str, suggest_orders: List[str], own_orders: List[str]
+        self, own: str, suggest_orders: Dict[str, List[str]], own_orders: List[str]
     ) -> Optional[str]:
         """Create prompt used as input to the LLM.
 
@@ -143,11 +142,8 @@ A MUN - BUR:
         sorted_board_states = {key: sorted(value) for key, value in board_states.items()}
         formated_board_states = self.format_boardstates(sorted_board_states)
         # opponent order prediction
-        parsed_data = json.loads(suggest_orders[0])
-        predicted_orders = parsed_data["payload"]["predicted_orders"]
-        formatted_opponent_orders = predicted_orders
         formatted_opponent_orders = "\n".join(
-            f"{power}: " + ", ".join(predicted_orders[power]) for power in predicted_orders
+            f"{power}: " + ", ".join(suggest_orders[power]) for power in suggest_orders
         )
         # own recommended order format
         formatted_recommended_orders = ", ".join(own_orders)
@@ -172,7 +168,11 @@ A MUN - BUR:
         return prompt
 
     def format_prompt_phase2(
-        self, own: str, suggest_orders: List[str], own_orders: List[str], rationales: Optional[str]
+        self,
+        own: str,
+        suggest_orders: Dict[str, List[str]],
+        own_orders: List[str],
+        rationales: Optional[str],
     ) -> Optional[str]:
         """Create prompt used as input to the LLM.
 
@@ -186,12 +186,8 @@ A MUN - BUR:
         sorted_board_states = {key: sorted(value) for key, value in board_states.items()}
         formated_board_states = self.format_boardstates(sorted_board_states)
 
-        parsed_data = json.loads(suggest_orders[0])
-        predicted_orders = parsed_data["payload"]["predicted_orders"]
-        formatted_opponent_orders = predicted_orders
-
         formatted_opponent_orders = "\n".join(
-            f"{power}: " + ", ".join(predicted_orders[power]) for power in predicted_orders
+            f"{power}: " + ", ".join(suggest_orders[power]) for power in suggest_orders
         )
         formatted_recommended_orders = ", ".join(own_orders)
         if formatted_recommended_orders == "":


### PR DESCRIPTION
I wrote most of these commits last month, but I haven't rushed to create a PR because no leakage was actually happening. However, I feel these API improvements will still be useful both for the bots in this repository and the bots in other repositories (which _might_ be using leaked messages).

I tested this PR using `RandomProposerAdvisor`, `LrProbsTextVisualAdvisor`, and `FaafAdvisor` without encountering any relevant issues. I also confirmed that no advice leakage was happening with `FaafAdvisor`.

I have made this PR as a draft because it needs to be merged after #43, which brings in a `diplomacy` update to provide a better message reading API.