### PR TITLE
Run `pytest` under stricter conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ precommit:
 .PHONY: test
 test:
 	export ASYNC_TEST_TIMEOUT=180 && \
-	pytest
+	python -X dev -bb -m pytest
 
 .PHONY: check
 check: precommit test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ score = false
 [tool.pytest.ini_options]
 addopts = "-ra --strict-config --strict-markers --verbosity=2"
 filterwarnings = [
-  "ignore::DeprecationWarning",
+  "error",
 ]
 minversion = "6.0"
 xfail_strict = true


### PR DESCRIPTION
This enables more errors and warnings, which should prevent regressing on problems that have already been fixed.