### PR TITLE
Prevent extra spaces in DAIDE-to-English output

### DIFF
--- a/src/chiron_utils/daide2eng.py
+++ b/src/chiron_utils/daide2eng.py
@@ -121,9 +121,9 @@ def and_items(items: Sequence[DaideObject]) -> str:
         return daide_to_en(items[0]) + " and " + daide_to_en(items[1]) + " "
     else:
         return (
-            ", ".join([daide_to_en(item) for item in items[:-1]])
+            ", ".join([daide_to_en(item).strip() for item in items[:-1]])
             + ", and "
-            + daide_to_en(items[-1])
+            + daide_to_en(items[-1]).strip()
             + " "
         )
 
@@ -136,9 +136,9 @@ def or_items(items: Sequence[DaideObject]) -> str:
         return daide_to_en(items[0]) + " or " + daide_to_en(items[1]) + " "
     else:
         return (
-            ", ".join([daide_to_en(item) for item in items[:-1]])
+            ", ".join([daide_to_en(item).strip() for item in items[:-1]])
             + ", or "
-            + daide_to_en(items[-1])
+            + daide_to_en(items[-1]).strip()
             + " "
         )
 


### PR DESCRIPTION
I noticed extra spaces before commas in the following message:

> I propose an order using ENG's army in LVP to support ENG's fleet in LON moving into WAL , an order holding ENG's fleet in EDI , and an order moving ENG's fleet in LON to ECH.

There is probably a better solution, but in the interest of making minimal changes, we now remove extra spaces in `and_items()` and `or_items()`.