### PR TITLE
Link to Git LFS-hosted LR model files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Most bots require specific instructions to build and run them properly:
       - `LrProbsTextVisualAdvisor`: Provides textual and visual advice about all powers
       - `LrProbsVisualAdvisor`: Provides visual advice about all powers
   - To build the bot, run `make build-baseline-lr` to generate the OCI image to run with Docker
-    - When running the bot outside of a container, download the latest model file from [lr_models - Google Drive](https://drive.google.com/drive/folders/1FuG3qY51wRkR8RgEBVY49-loln06W-Ro). The filename includes the model release date in `YYYYMMDD` format).
+    - When running the bot outside of a container, download the latest model file from [`large-file-storage/lr_models/`](https://github.com/ALLAN-DIP/large-file-storage/tree/main/lr_models). The filename includes the model release date in `YYYYMMDD` format).
     - Edit the `MODEL_PATH` constant in `lr_bot.py` to point to the unzipped model folder.
   - Code for model training can be found at <https://github.com/ALLAN-DIP/baseline-models>
 - LLM advisor bots:


### PR DESCRIPTION
The models were being stored on Google Drive, which is not accessible to external viewers. I therefore uploaded them to GitHub as Git LFS files. I described the process in the commits that added them.[^1]

[^1]: https://github.com/ALLAN-DIP/large-file-storage/compare/635cabd6352b3750cc54cc34dd2b86cebe3d82d3...bc73b2e490b76585c56ee8d9ef49da9d269389e2