### PR TITLE
Download FAAF model from Hugging Face Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Most bots require specific instructions to build and run them properly:
       - Request access on the page for the following model:
         - [Llama3.1-8b-instruct](https://huggingface.co/meta-llama/Meta-Llama-3.1-8B-Instruct)
       - Once your request has been approved, authenticate on your local machine using a user access token, using the official [User access tokens](https://huggingface.co/docs/hub/security-tokens) documentation as a guide.
-    - When using `FaafAdvisor`, download the [FAAF model checkpoint](https://drive.google.com/file/d/15qGrovFkkOAJd42l1yFtfzzhOCytIbC-/view) and unzip it into the directory [`src/chiron_utils/models/`](src/chiron_utils/models/).
     - When using `LlmAdvisor`, one needs to run another advisor to provide `OPPONENT_MOVE` advice to the same power. For example, one can run the [Cicero advisor](https://github.com/ALLAN-DIP/diplomacy_cicero) with the argument `--advice_levels OPPONENT_MOVE`.
     - When using `FaafAdvisor` or `LlmNewAdvisor`, one needs to run another advisor to provide `MOVE|OPPONENT_MOVE` advice to the same power. For example, one can run the [Cicero advisor](https://github.com/ALLAN-DIP/diplomacy_cicero) with the argument `--advice_levels 'MOVE|OPPONENT_MOVE'`.
   - To use the bot, run the following command from the repository root, replacing `[bot_type]` with the bot's name:

--- a/src/chiron_utils/bots/csu_faaf_advisor_bot.py
+++ b/src/chiron_utils/bots/csu_faaf_advisor_bot.py
@@ -31,7 +31,7 @@ class FaafAdvisor(BaselineBot):
         default_factory=lambda: dict.fromkeys(POWER_NAMES_DICT)
     )
     base_model_name = "meta-llama/Llama-3.1-8B-Instruct"
-    adapter_path = "src/chiron_utils/models/DELI_faaf_weights/checkpoint-2000"
+    adapter_name = "Abhijnan/Delidata_friction_agent"
     device = "cuda" if torch.cuda.is_available() else "cpu"
     bot_type = BotType.ADVISOR
     default_suggestion_type = SuggestionType.COMMENTARY
@@ -42,7 +42,7 @@ class FaafAdvisor(BaselineBot):
         # used to avoid repeated generation
         self.previous_prompt: Optional[str] = None
         self.tokenizer, self.model = self.load_model(
-            self.base_model_name, self.adapter_path, self.adapter_path, self.device
+            self.base_model_name, self.adapter_name, self.adapter_name, self.device
         )
 
     async def start_phase(self) -> None:
@@ -203,17 +203,17 @@ class FaafAdvisor(BaselineBot):
     def load_model(
         self,
         base_model_name: str,
-        adapter_path: str,
-        tokenizer_path: Optional[str] = None,
+        adapter_name: str,
+        tokenizer_name: Optional[str] = None,
         device: str = "cpu",
     ) -> Tuple[PreTrainedTokenizer, Union[PreTrainedModel, DataParallel]]:
         """Loads and returns a tokenizer and model on the requested device."""
-        if tokenizer_path is None:
-            tokenizer_path = base_model_name
+        if tokenizer_name is None:
+            tokenizer_name = base_model_name
 
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
         model = AutoModelForCausalLM.from_pretrained(base_model_name)
-        model = PeftModel.from_pretrained(model, adapter_path)
+        model = PeftModel.from_pretrained(model, adapter_name)
         if torch.cuda.device_count() > 1:
             model = DataParallel(model)
         model.to(device)

--- a/src/chiron_utils/bots/csu_faaf_advisor_bot.py
+++ b/src/chiron_utils/bots/csu_faaf_advisor_bot.py
@@ -289,9 +289,16 @@ class FaafAdvisor(BaselineBot):
 
         filtered_opponent_orders = self.read_suggested_opponent_orders()
         if not filtered_opponent_orders:
+            logger.error(
+                f"No opponent orders given, run "
+                f"an {SuggestionType.OPPONENT_MOVE.to_parsable()!r} advisor"
+            )
             return []
         filtered_own_orders = self.read_suggested_orders()
         if not filtered_own_orders:
+            logger.error(
+                f"No self orders given, run a {SuggestionType.MOVE.to_parsable()!r} advisor"
+            )
             return []
         own = self.power_name
         if own in POWER_NAMES_DICT:


### PR DESCRIPTION
Instead of hosting the model in Google Drive, we should use the model directly from the Hugging Face Hub. This is more reliable long-term storage, and it makes downloading the model automatic.

I also added some error messages to make a user mistake I made (forgetting to run a move advisor) more obvious.